### PR TITLE
requirements.txt: List of Pip packages needed by this Jupyter sheet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+jupyter
+matplotlib
+numpy
+pandas
+requests


### PR DESCRIPTION
For those not using Anaconda, it's handy to give people a list of the packages they need. The added file `requirements.txt` lists them and they can be installed directly from that list with `pip install -r requirements.txt`.

Future work might include a shell script to deal with checking that the appropriate packages exist before starting `jupyter notebook` for you. (Most Windows users with Git will also have Bash available.)